### PR TITLE
yq4 syntax for pr release script

### DIFF
--- a/bin/pr-release
+++ b/bin/pr-release
@@ -10,14 +10,8 @@ git config --global user.name "${GITHUB_USER}"
 
 filename=$1
 git checkout -b $CIRCLE_PROJECT_REPONAME-$CIRCLE_TAG 
-sed -i -e 's/^\([[:space:]]*\)values: |/\1values:/g' $filename
-yq w "$filename" spec.source.helm.values.image.tag $CIRCLE_TAG -i 
-sed -i -e 's/[[:space:]]values:/ values: |/g' "$filename"
 
-if [[ ! $(yq read $filename metadata.annotations.appVersion) == "null" ]]; then 
-  echo "adding appVersion"
-  yq w "$filename" metadata.annotations.appVersion $CIRCLE_TAG -i
-fi
+yq -i ".spec.source.helm.valuesObject.image.tag=\"$CIRCLE_TAG\"" "$filename"
 
 git add $filename 
 git commit -m "release $CIRCLE_TAG for $CIRCLE_PROJECT_REPONAME"


### PR DESCRIPTION
we were in the process of moving to yq4, and this script got missed, using `valuesObject` instead of `values` string, too. we'll have to keep that in mind as a pre-req if folks are using ci-utils 4.x