### PR TITLE
Add TO_YAML_TAG_TARGET support for image-release scripts

### DIFF
--- a/bin/image-release-for-clusters
+++ b/bin/image-release-for-clusters
@@ -16,6 +16,9 @@ Environment (preferred):
   - CONFIG_REPO (optional): git URL to infer CONFIG_REPO_NAME
   - CIRCLE_PROJECT_REPONAME (preferred): name of the project; used for manifest path
   - FROM_TAG / TO_TAG (required by image-tag / image-release-pr)
+  - TO_YAML_TAG_TARGET (optional): YAML path for where the image tag lives in the manifest
+    (passed through to image-release-pr; default inside image-release-pr is
+    `.spec.source.helm.values.image.tag`)
 
 If the new script is not available in CI, the pipeline will fall back to the original inline implementation.
 EOF
@@ -99,6 +102,7 @@ for cluster in "${CLUSTERS_ARR[@]}"; do
   export TARGET_CLUSTER="$cluster"
   manifest_path="clusters/$TARGET_CLUSTER/manifests/$REGISTRY_REPO/prod.yaml"
   echo "Processing cluster: $TARGET_CLUSTER -> $manifest_path"
+  echo "  TO_YAML_TAG_TARGET: ${TO_YAML_TAG_TARGET:-(default)}"
 
   if [[ ! -f "$manifest_path" ]]; then
     echo "Error: manifest not found: $manifest_path"
@@ -106,7 +110,7 @@ for cluster in "${CLUSTERS_ARR[@]}"; do
     continue
   fi
 
-  if ! /usr/local/bin/image-release-pr "$manifest_path"; then
+  if ! TO_YAML_TAG_TARGET="${TO_YAML_TAG_TARGET:-}" /usr/local/bin/image-release-pr "$manifest_path"; then
     echo "Error: image-release-pr failed for $manifest_path"
     had_error=1
   fi

--- a/bin/image-release-pr
+++ b/bin/image-release-pr
@@ -59,7 +59,7 @@ if [[ ! -f "$filename" ]]; then
   exit 1
 fi
 
-if [[ -z "$TO_YAML_TAG_TARGET" ]]; then
+if [[ -z "${TO_YAML_TAG_TARGET:-}" ]]; then
   echo "Warning: TO_YAML_TAG_TARGET not set, defaulting to .spec.source.helm.values.image.tag"
 fi
 TO_YAML_TAG_TARGET="${TO_YAML_TAG_TARGET:-.spec.source.helm.values.image.tag}"


### PR DESCRIPTION
- Introduced TO_YAML_TAG_TARGET as an optional parameter for specifying the YAML path of the image tag in the manifest.
- Updated usage documentation to reflect the new parameter.
- Added logging for TO_YAML_TAG_TARGET in the image-release-for-clusters script.
- Ensured backward compatibility by defaulting TO_YAML_TAG_TARGET in image-release-pr.